### PR TITLE
fix: initialize overlay on map load

### DIFF
--- a/src/components/EventPanel.tsx
+++ b/src/components/EventPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { 
-  Play, Pause, RotateCcw, Eye, EyeOff, 
+import {
+  Play, Pause, Eye, EyeOff,
   AlertCircle, AlertTriangle, Info,
   Clock, Settings, Layers
 } from 'lucide-react';


### PR DESCRIPTION
## Summary
- initialize MapboxOverlay when the map loads so arcs/hubs/labels render
- type map ref and remove unused icon import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68984c7ba0088325b117baf7598ef193