### PR TITLE
feat: add cable geojson layer

### DIFF
--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -33,7 +33,9 @@ const initialState: RootState = {
   },
   seed: 42,
   refreshMs: 3000,
-  lastUpdate: 0
+  lastUpdate: 0,
+  cables: null,
+  highlightedCableId: undefined
 };
 
 let updateInterval: NodeJS.Timeout | null = null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,8 @@ export interface KPI {
   trend: number[];
 }
 
+import type { FeatureCollection, LineString } from 'geojson';
+
 export interface EventItem {
   id: string;
   tsISO: string;
@@ -45,6 +47,12 @@ export interface UiState {
   focusHubId?: string;
 }
 
+export interface CableProperties {
+  color: [number, number, number];
+}
+
+export type CableCollection = FeatureCollection<LineString, CableProperties>;
+
 export interface RootState {
   hubs: Hub[];
   links: Link[];
@@ -54,4 +62,6 @@ export interface RootState {
   seed: number;
   refreshMs: number;
   lastUpdate: number;
+  cables: CableCollection | null;
+  highlightedCableId?: string;
 }


### PR DESCRIPTION
## Summary
- render cables on globe via GeoJsonLayer with highlight support
- extend store and types for cable data and highlighted cable tracking

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898515e15b88325baca87c1ad43a21b