### PR TITLE
Add cable highlighting logic

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { Feature } from 'geojson';
+
 export interface Hub {
   id: string;
   name: string;
@@ -54,4 +56,6 @@ export interface RootState {
   seed: number;
   refreshMs: number;
   lastUpdate: number;
+  cables: Feature[];
+  highlightedCableId?: string;
 }


### PR DESCRIPTION
## Summary
- store submarine cable features and current highlight in RootState
- fetch cable GeoJSON and run an interval to randomly highlight cables

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898515f7e488325914551bca0c577e1